### PR TITLE
improved tool directions in agentic exercise

### DIFF
--- a/scripts/.tool-versions
+++ b/scripts/.tool-versions
@@ -1,1 +1,0 @@
-local python 3.12

--- a/scripts/.tool-versions
+++ b/scripts/.tool-versions
@@ -1,0 +1,1 @@
+local python 3.12

--- a/scripts/12-agentic_basic.py
+++ b/scripts/12-agentic_basic.py
@@ -16,12 +16,17 @@ load_dotenv()
 
 
 class SearchInput(BaseModel):
-    query: str = Field(description="should be a search query")
+    query: str = Field(
+        description="ONLY the function name - no extra words (e.g., 'can_create_project', 'login_required')"
+    )
 
 
 class CustomSearchTool(BaseTool):
-    name: str = "custom_search"
-    description: str = "Useful for when you need to answer questions about code"
+    name: str = "function_lookup"
+    description: str = (
+        "Look up a specific function definition. Input must be EXACTLY the function name with no additional words. "
+        "CORRECT: 'can_create_project' | INCORRECT: 'can_create_project function' or 'authorization check'"
+    )
     args_schema: Type[SearchInput] = SearchInput
 
     def _run(
@@ -39,7 +44,7 @@ class CustomSearchTool(BaseTool):
     async def _arun(
         self, query: str, run_manager: Optional[CallbackManagerForToolRun] = None
     ) -> str:
-        raise NotImplementedError("custom_search does not support async")
+        raise NotImplementedError("function_lookup does not support async")
 
 
 # Define tools and LLM


### PR DESCRIPTION
This pull request updates the implementation of a custom search tool in `scripts/12-agentic_basic.py` to clarify its purpose and improve its usability. The changes focus on making the tool specifically for function lookups, ensuring that inputs are strictly function names, and updating related descriptions and error messages.

**Function lookup tool improvements:**

* Renamed the tool from `custom_search` to `function_lookup` and updated its description to specify that it is only for looking up exact function names, with clear examples of correct and incorrect inputs.
* Changed the error message in the asynchronous method to reference `function_lookup` instead of `custom_search`.
* Updated the `query` field description in the `SearchInput` model to require only the function name, removing ambiguity about the input format.